### PR TITLE
이슈 #8 해결

### DIFF
--- a/src/main/java/Game.java
+++ b/src/main/java/Game.java
@@ -103,7 +103,7 @@ class Game {
                     }
                     Piece chosen = player.pieces.get(pieceIdx);
                     if (chosen.finished) {
-                        System.out.println("이미 완주한 말입니다. 다른 말을 선택해주세요.");
+                        System.out.println("이미 완주된 말입니다");
                         continue;
                     }
 

--- a/src/main/java/Game.java
+++ b/src/main/java/Game.java
@@ -1,4 +1,3 @@
-//Game.java
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
@@ -7,7 +6,7 @@ import java.util.Scanner;
 class Game {
     List<Player> players;
     Board board;
-    int currentTurn = 0; //플레이어 인덱스
+    int currentTurn = 0; // 플레이어 인덱스
     Random random = new Random();
 
     public Game(int numPlayers, int piecesPerPlayer, Board board) {
@@ -27,17 +26,17 @@ class Game {
 
             System.out.println("윷 던지기 방식 선택 (1: 지정, 2: 랜덤): ");
             int mode = scanner.nextInt();
-            List<YutResult> results = new ArrayList<>(); //윷 결과 리스트
+            List<YutResult> results = new ArrayList<>(); // 윷 결과 리스트
 
-            boolean extra = false; //윷,모일 때 추가 던지기
-            if (mode == 1) { //지정일 때
-                do{
-                    if(extra){
+            boolean extra = false; // 윷, 모일 때 추가 던지기 여부
+            if (mode == 1) { // 지정 모드
+                do {
+                    if (extra) {
                         System.out.println("추가 윷 던지기 기회 발생!");
                     }
                     System.out.println("번호 선택: 1. 빽도  2. 도  3. 개  4. 걸  5. 윷  6. 모");
                     int choice = scanner.nextInt();
-                    YutResult res = null;
+                    YutResult res;
                     switch (choice) {
                         case 1: res = YutResult.BACKDO; break;
                         case 2: res = YutResult.DO; break;
@@ -49,10 +48,10 @@ class Game {
                             System.out.println("잘못된 선택");
                             continue;
                     }
-                    extra = res.grantsExtraThrow();
                     results.add(res);
-                } while(extra);
-            } else {
+                    extra = res.grantsExtraThrow();
+                } while (extra);
+            } else { // 랜덤 모드
                 do {
                     YutResult res = YutResult.throwYut(random);
                     results.add(res);
@@ -78,10 +77,10 @@ class Game {
                 int resIdx = scanner.nextInt();
                 if (resIdx < 0 || resIdx >= results.size()) {
                     System.out.println("잘못된 인덱스입니다. 다시 입력해주세요.");
-                    continue;        // 리스트 유지, 기회 차감 없음
+                    continue; // 리스트 유지
                 }
 
-                YutResult selectedRes = results.remove(resIdx); //선택된 결과 리스트에서 제거
+                YutResult selectedRes = results.remove(resIdx);
                 System.out.println("선택한 결과: " + selectedRes);
 
                 while (true) {
@@ -108,9 +107,41 @@ class Game {
                         continue;
                     }
 
-                    // 말 이동 시키기
-                    board.movePiece(chosen, selectedRes.getStepCount(), scanner);
+                    // 말 이동
+                    boolean captureOccurred = board.movePiece(chosen, selectedRes.getStepCount(), scanner);
                     System.out.println(chosen + " 이동 완료.");
+
+                    // 캡처 시 추가 던지기 (연속 가능)
+                    if (captureOccurred) {
+                        System.out.println("말을 잡았습니다! 추가 던지기 기회 발생!");
+                        if (mode == 1) {
+                            YutResult extraRes;
+                            do {
+                                System.out.println("추가 윷 던지기 기회! 번호 선택: 1. 빽도  2. 도  3. 개  4. 걸  5. 윷  6. 모");
+                                int choice = scanner.nextInt();
+                                switch (choice) {
+                                    case 1: extraRes = YutResult.BACKDO; break;
+                                    case 2: extraRes = YutResult.DO; break;
+                                    case 3: extraRes = YutResult.GAE; break;
+                                    case 4: extraRes = YutResult.GEOL; break;
+                                    case 5: extraRes = YutResult.YUT; break;
+                                    case 6: extraRes = YutResult.MO; break;
+                                    default:
+                                        System.out.println("잘못된 선택, 랜덤으로 처리합니다.");
+                                        extraRes = YutResult.throwYut(random);
+                                        System.out.println("추가 윷 결과: " + extraRes);
+                                }
+                                results.add(extraRes);
+                            } while (extraRes.grantsExtraThrow());
+                        } else {
+                            YutResult extraRes;
+                            do {
+                                extraRes = YutResult.throwYut(random);
+                                System.out.println("추가 윷 결과: " + extraRes);
+                                results.add(extraRes);
+                            } while (extraRes.grantsExtraThrow());
+                        }
+                    }
                     break;
                 }
             }


### PR DESCRIPTION
game 클래스 수정하여 이동할 윷 선택 시 완주한 말을 선택하면 그냥 턴이 넘어가던 오류를 수정함.
이미 완주한 말을 선택시 "이미 완주한 말입니다"라는 텍스트와 함께 다시 선택할 수 있게 함.