### PR TITLE
Fix : start 지점 도착 이후 완주 & 연속 빽도 로직 & start 지점 빽도 (전진) 로직

### DIFF
--- a/src/main/java/Board.java
+++ b/src/main/java/Board.java
@@ -35,38 +35,103 @@ abstract class Board {
      * 말 이동: 5번,10번,28번에 대한 특별 숏컷, 지연 숏컷, 빽도, 업, 캡처 처리
      */
     public boolean movePiece(Piece piece, int steps, Scanner scanner) {
-        System.out.println("[DEBUG] " + piece.owner.getName() + " 호출 movePiece(steps=" + steps + ")");
-        boolean delayed = piece.justStoppedAtIntersection;
-
-        // 기본: outer 따라서
-        // curr 노드가 intersection이면 shortcut으로(마지막 intersection 제외)
-        // 0. 빽도 처리
-        if (steps == -1) {
-            if (piece.position == null || piece.moveHistory.isEmpty()) {
-                System.out.println("빽도 불가. 제자리에 머뭅니다."); return false;
-            }
-            // 1) 현재 위치 제거
-            piece.moveHistory.pop();
-            // 2) 한 칸 전 위치 꺼내기
-            BoardNode prev = piece.moveHistory.pop();
-            //if (piece.position.id == 24 && !piece.moveHistory.isEmpty() && piece.moveHistory.peek().id == 28)
-              //  prev = piece.moveHistory.pop();
-            piece.position.pieces.remove(piece);
-            boolean cap=false;
-            for (Piece e : new ArrayList<>(prev.pieces)) if (e.owner!=piece.owner) {
-                cap=true; prev.pieces.remove(e); e.position=null;
-                System.out.println("[DEBUG] 빽도로 캡처: " + e.owner.getName());
-            }
-            prev.pieces.add(piece); piece.position = prev;
-            // backdo 후 위치가 교차점인지 플래그 설정
-            piece.justStoppedAtIntersection = (prev.isIntersection && prev.shortcut != null);
-            return cap;
-        }
 
         // 1. 첫 entry 및 업 플래그
         boolean first = (piece.position==null); //처음 입장하는 경우
         BoardNode src = first? getStart(): piece.position; //현재 보드노드(추적)
-        if (first) piece.hasLeftStart=false;
+        if (first) piece.hasLeftStart=true;
+        System.out.println("[DEBUG] " + piece.owner.getName() + " 호출 movePiece(steps=" + steps + ")");
+        boolean delayed = piece.justStoppedAtIntersection;
+
+
+        debugPrintAllNodes();
+
+        // 기본: outer 따라서
+        // curr 노드가 intersection이면 shortcut으로(마지막 intersection 제외)
+        // 0) 빽도 처리: steps == -1
+        if (steps == -1) {
+            // 0-a) 아직 보드에 안 올랐으면 불가
+            if (piece.position == null) {
+                System.out.println("아직 보드에 진입하지 않아 빽도 불가.");
+                return false;
+            }
+            System.out.println("[DEBUG] 이전 위치 : " + piece.lastPosition);
+
+            if (piece.position == getStart()
+                    && piece.hasLeftStart
+                    && piece.moveHistory.size() == 1) {
+                System.out.println("start 지점에서 빽도! → 이전 위치로 돌아갑니다.");
+
+                // 1) lastPosition 으로 돌아가기
+                BoardNode prev = piece.lastPosition;
+
+                // 2) 보드 상 위치 갱신
+                getStart().pieces.remove(piece);
+                prev.pieces.add(piece);
+                piece.position = prev;
+                piece.justStoppedAtIntersection = prev.isIntersection && prev.shortcut != null;
+
+                // 3) moveHistory 재설정: [start, prev]
+                piece.moveHistory.clear();
+                piece.moveHistory.push(getStart());
+                piece.moveHistory.push(prev);
+
+                return false;
+            }
+
+            // 0-c) 이동 이력 없으면 불가
+            if (piece.moveHistory.isEmpty()) {
+                System.out.println("이전 위치 정보가 없어 빽도 불가.");
+                return false;
+            }
+
+            // 0-d) 정상적인 한 칸 뒤로 이동
+            if (piece.moveHistory.size() > 1) {
+                piece.moveHistory.pop();
+            }
+            BoardNode prev = piece.moveHistory.peek();
+            piece.position.pieces.remove(piece);
+
+            boolean captured = false;
+            for (Piece enemy : new ArrayList<>(prev.pieces)) {
+                if (enemy.owner != piece.owner) {
+                    captured = true;
+                    prev.pieces.remove(enemy);
+                    enemy.position = null;
+                    System.out.println(enemy.owner.getName()
+                            + "의 말이 빽도로 캡처되어 집으로 돌아갑니다.");
+                }
+            }
+
+            // 1) 일반 이동에 들어가기 직전, lastPosition 에 현재 위치 저장
+            piece.lastPosition = piece.position == null
+                    ? getStart()  // 첫 진입인 경우 start 가 이전 위치
+                    : piece.position;
+
+            prev.pieces.add(piece);
+            piece.position = prev;
+            // 빽도 후에도 intersection 여부 유지
+            piece.justStoppedAtIntersection = prev.isIntersection && prev.shortcut != null;
+            System.out.println(piece.owner.getName()
+                    + "의 말이 빽도로 " + prev + "로 한 칸 뒤로 이동했습니다.");
+            return captured;
+
+
+        }
+
+        // 1) 일반 이동에 들어가기 직전, lastPosition 에 현재 위치 저장
+        piece.lastPosition = piece.position == null
+                ? getStart()  // 첫 진입인 경우 start 가 이전 위치
+                : piece.position;
+
+        // 2) “start에서 positive step” 완주 처리
+        //    — 이미 보드에 올라갔었고(start를 한번 떠난 적이 있고),
+        //      지금 위치가 start이며, steps>0 이면 즉시 완주
+        if (!first && src == getStart() && piece.hasLeftStart && steps > 0) {
+            piece.finished = true;
+            System.out.println(piece.owner.getName() + "의 말이 완주했습니다! (start에서 positive step)");
+            return false;
+        }
 
         //2. 경로 설정
         BoardNode cur = src;
@@ -113,7 +178,7 @@ abstract class Board {
         if (src.id==5 && !delayed) {
             BoardNode fb=src; for(int i=0;i<steps;i++) fb=fb.next; dest=fb;
         }
-        
+
         // 3) 업(스택) 기능
         List<Piece> stack=new ArrayList<>();
         if (first) stack.add(piece);
@@ -131,16 +196,22 @@ abstract class Board {
             return false;
         }
 
-     
+
         // 5. 캡처
         boolean capO=false;
         for(Piece e:new ArrayList<>(dest.pieces)) if(e.owner!=piece.owner){capO=true; dest.pieces.remove(e); e.position=null;
             System.out.println(e.owner.getName()+"의 말이 캡처되어 집으로 돌아갑니다.");}
 
         // 6. 이동 및 이력
-        for(Piece p:stack){ p.moveHistory.push(src); for(BoardNode n:path) p.moveHistory.push(n); dest.pieces.add(p); p.position=dest; }
+        for(Piece p:stack){
+            p.moveHistory.push(src);
+            for(BoardNode n:path)
+                p.moveHistory.push(n);
+            dest.pieces.add(p);
+            p.position=dest;
+        }
         System.out.println(piece.owner.getName()+"의 말("+stack.size()+"개)이 "+dest+"로 이동했습니다.");
-        debugPrintAllNodes(); return capO;
+        return capO;
     }
 
     public void debugPrintAllNodes(){ System.out.print("[DEBUG BOARD] "); for(BoardNode n:nodes) System.out.print(n.id+"["+n.pieces.size()+"] "); System.out.println(); }

--- a/src/main/java/Piece.java
+++ b/src/main/java/Piece.java
@@ -3,6 +3,7 @@ import java.util.Stack;
 class Piece {
     Player owner;
     BoardNode position; //말이 위치한 보드노드
+    BoardNode lastPosition;         // ← 이전 위치 저장용
     boolean finished;
     boolean hasLeftStart = false;           // 한 바퀴 나감 플래그
     Stack<BoardNode> moveHistory = new Stack<>(); // 이동 이력
@@ -17,7 +18,7 @@ class Piece {
 
     @Override
     public String toString() {
-        String info = "말@" + (position != null ? position.name : "집");
+        String info = "말 위치 : " + (position != null ? position.name : "집");
         if (finished) info += "(완주)";
         return info;
     }

--- a/src/test/java/AllUnitGameTest.java
+++ b/src/test/java/AllUnitGameTest.java
@@ -23,8 +23,10 @@ public class AllUnitGameTest {
     Piece piece;
     Scanner scanner;
 
+
     @BeforeAll
     void setUp() {
+
         board3 = new HexagonBoard();
         player = new Player("Player1", 2, board3);
         piece = player.pieces.get(0);
@@ -80,6 +82,284 @@ public class AllUnitGameTest {
         assertNotNull(p2.position, "p2.position이 null입니다.");
         assertEquals(p1.position, p2.position, "p1과 p2는 같은 위치에 있어야 합니다.");
         assertEquals("3", p1.position.name, "말의 위치는 3번 노드여야 합니다.");
+    }
+
+    @Test
+    void testStartPointBaekDo() {
+        SquareBoard board = new SquareBoard();
+        Player player = new Player("P", 1, board);
+        Piece piece = player.pieces.get(0);
+
+        board.movePiece(piece, 1, scanner);  // 도 -> 1
+        board.movePiece(piece, -1, scanner);  // 빽도 -> 0
+        assertEquals(0, piece.position.id, "현재 위치는 2이어야 합니다.");
+        board.movePiece(piece, -1, scanner);  // 빽도 → 1
+        assertEquals(1, piece.position.id, "현재 위치는 2이어야 합니다.");
+        board.movePiece(piece, 2, scanner);  // 개 → 3
+        board.movePiece(piece, -1, scanner);  // 빽도 → 2
+
+        assertFalse(piece.finished, "이 시나리오에서는 완주되지 않아야 합니다.");
+        assertEquals(2, piece.position.id, "최종 위치는 2이어야 합니다.");
+    }
+
+    @Test
+    void testStartPointBaekDo2() {
+        SquareBoard board = new SquareBoard();
+        Player player = new Player("P", 1, board);
+        Piece piece = player.pieces.get(0);
+
+        board.movePiece(piece, 1, scanner);  // 도 -> 1
+        board.movePiece(piece, -1, scanner);  // 빽도 -> 0
+        assertEquals(0, piece.position.id, "현재 위치는 0이어야 합니다.");
+        board.movePiece(piece, -1, scanner);  // 빽도 → 1
+        assertEquals(1, piece.position.id, "현재 위치는 1이어야 합니다.");
+        board.movePiece(piece, -1, scanner);  // 빽도 → 0
+        assertEquals(0, piece.position.id, "현재 위치는 0이어야 합니다.");
+        board.movePiece(piece, 2, scanner);  // 개 → 완주
+
+        assertTrue(piece.finished, "이 시나리오에서는 완주되어야 합니다.");
+    }
+
+    // ────────────────────────────────────────────────────────────
+    // 사각형 판 시나리오
+    // ────────────────────────────────────────────────────────────
+
+    /** a. 0(윷)→4(개)→6(윷)→10(윷)→26(걸)→완주 */
+    @Test
+    void testSquareScenarioA() {
+        SquareBoard board = new SquareBoard();
+        Player player = new Player("P", 1, board);
+        Piece piece = player.pieces.get(0);
+
+        board.movePiece(piece, 4, scanner);  // 윷
+        board.movePiece(piece, 2, scanner);  // 개
+        board.movePiece(piece, 4, scanner);  // 윷
+        board.movePiece(piece, 4, scanner);  // 윷
+        board.movePiece(piece, 3, scanner);  // 걸
+
+        assertTrue(piece.finished, "말이 완주되어야 합니다.");
+    }
+
+    /** b. 0(윷)→4(윷)→8(개)→10(윷)→26 (미완주) */
+    @Test
+    void testSquareScenarioB() {
+        SquareBoard board = new SquareBoard();
+        Player player = new Player("P", 1, board);
+        Piece piece = player.pieces.get(0);
+
+        board.movePiece(piece, 4, scanner);  // 윷 → 4
+        board.movePiece(piece, 4, scanner);  // 윷 → 8
+        board.movePiece(piece, 2, scanner);  // 개 → 10
+        board.movePiece(piece, 4, scanner);  // 윷 → 26
+
+        assertFalse(piece.finished, "완주되지 않아야 합니다.");
+        assertEquals(26, piece.position.id, "최종 위치는 26이어야 합니다.");
+    }
+
+    /** c. 0(윷)→4(윷)→8(윷)→12(걸)→15(걸)→18 */
+    @Test
+    void testSquareScenarioC() {
+        SquareBoard board = new SquareBoard();
+        Player player = new Player("P", 1, board);
+        Piece piece = player.pieces.get(0);
+
+        board.movePiece(piece, 4, scanner);  // 윷 → 4
+        board.movePiece(piece, 4, scanner);  // 윷 → 8
+        board.movePiece(piece, 4, scanner);  // 윷 → 12
+        board.movePiece(piece, 3, scanner);  // 걸 → 15
+        board.movePiece(piece, 3, scanner);  // 걸 → 18
+
+        assertFalse(piece.finished, "이 시나리오에서는 완주되지 않아야 합니다.");
+        assertEquals(18, piece.position.id, "최종 위치는 18이어야 합니다.");
+    }
+
+    /** d. 0(모) -> 5(걸) -> 28(걸) -> 0(개) -> 완주 */
+    @Test
+    void testSquareScenarioD() {
+        SquareBoard board = new SquareBoard();
+        Player player = new Player("P", 1, board);
+        Piece p = player.pieces.get(0);
+
+        // 모(5)
+        board.movePiece(p, YutResult.MO.getStepCount(), scanner);
+        assertEquals("5", p.position.name);
+
+        // 걸(3) → 28
+        board.movePiece(p, YutResult.GEOL.getStepCount(), scanner);
+        assertEquals("28", p.position.name);
+
+        // 걸(3) → 0 (완주 직전)
+        board.movePiece(p, YutResult.GEOL.getStepCount(), scanner);
+        assertEquals("0", p.position.name);
+
+        // 개(2) → 완주
+        board.movePiece(p, YutResult.GAE.getStepCount(), scanner);
+        assertTrue(p.finished, "개를 던진 후 완주되어야 합니다.");
+    }
+
+    /** e. 0(모) -> 5(윷) -> 24(걸) -> 16 */
+    @Test
+    void testSquareScenarioE() {
+        SquareBoard board = new SquareBoard();
+        Player player = new Player("P", 1, board);
+        Piece p = player.pieces.get(0);
+
+        // 모(5) → 5
+        board.movePiece(p, YutResult.MO.getStepCount(), scanner);
+        assertEquals("5", p.position.name);
+
+        // 윷(4) → 24 (5번에서 숏컷)
+        board.movePiece(p, YutResult.YUT.getStepCount(), scanner);
+        assertEquals("24", p.position.name);
+
+        // 걸(3) → 16
+        board.movePiece(p, YutResult.GEOL.getStepCount(), scanner);
+        assertEquals("16", p.position.name);
+    }
+
+    // ────────────────────────────────────────────────────────────
+    // 오각형 판 시나리오
+    // ────────────────────────────────────────────────────────────
+
+    /** a. 0(모)→5(개)→26(걸)→32 */
+    @Test
+    void testPentagonScenarioA() {
+        PentagonBoard board = new PentagonBoard();
+        Player player = new Player("P", 1, board);
+        Piece piece = player.pieces.get(0);
+
+        board.movePiece(piece, 5, scanner);  // 모 → 5
+        board.movePiece(piece, 2, scanner);  // 개 → 26
+        board.movePiece(piece, 3, scanner);  // 걸 → 32
+
+        assertFalse(piece.finished, "이 시나리오에서는 완주되지 않아야 합니다.");
+        assertEquals(32, piece.position.id, "최종 위치는 32이어야 합니다.");
+    }
+
+    /** b. 0(모)→5(걸)→35(걸)→0 */
+    @Test
+    void testPentagonScenarioB() {
+        PentagonBoard board = new PentagonBoard();
+        Player player = new Player("P", 1, board);
+        Piece piece = player.pieces.get(0);
+
+        board.movePiece(piece, 5, scanner);  // 모 → 5
+        board.movePiece(piece, 3, scanner);  // 걸 → 35
+        board.movePiece(piece, 3, scanner);  // 걸 → 0
+
+        assertFalse(piece.finished, "완주 플래그는 지나치기 전까지는 켜지지 않습니다.");
+        assertEquals(board.getStart(), piece.position, "최종 위치는 출발점이어야 합니다.");
+    }
+
+    /** c. 0(모)→5(윷)→31(걸)→21 */
+    @Test
+    void testPentagonScenarioC() {
+        PentagonBoard board = new PentagonBoard();
+        Player player = new Player("P", 1, board);
+        Piece piece = player.pieces.get(0);
+
+        board.movePiece(piece, 5, scanner);  // 모 → 5
+        board.movePiece(piece, 4, scanner);  // 윷 → 31
+        board.movePiece(piece, 3, scanner);  // 걸 → 21
+
+        assertFalse(piece.finished, "이 시나리오에서는 완주되지 않아야 합니다.");
+        assertEquals(21, piece.position.id, "최종 위치는 21이어야 합니다.");
+    }
+
+    /** d. 0(윷) -> 4(걸) -> 7(걸) -> 10(개) -> 28(걸) -> 32 */
+    @Test
+    void testPentagonScenarioD() {
+        PentagonBoard board = new PentagonBoard();
+        Player player = new Player("P", 1, board);
+        Piece p = player.pieces.get(0);
+
+        // 윷(4) → 4
+        board.movePiece(p, YutResult.YUT.getStepCount(), scanner);
+        assertEquals("4", p.position.name);
+
+        // 걸(3) → 7
+        board.movePiece(p, YutResult.GEOL.getStepCount(), scanner);
+        assertEquals("7", p.position.name);
+
+        // 걸(3) → 10
+        board.movePiece(p, YutResult.GEOL.getStepCount(), scanner);
+        assertEquals("10", p.position.name);
+
+        // 개(2) → 28 (10번에서 숏컷으로 중앙 진입 → 28)
+        board.movePiece(p, YutResult.GAE.getStepCount(), scanner);
+        assertEquals("28", p.position.name);
+
+        // 걸(3) → 32
+        board.movePiece(p, YutResult.GEOL.getStepCount(), scanner);
+        assertEquals("32", p.position.name);
+    }
+
+    /** e. 0(윷) -> 4(걸) -> 7(걸) -> 10(걸) -> 35(걸) -> 0 */
+    @Test
+    void testPentagonScenarioE() {
+        PentagonBoard board = new PentagonBoard();
+        Player player = new Player("P", 1, board);
+        Piece p = player.pieces.get(0);
+
+        // 윷(4) → 4
+        board.movePiece(p, YutResult.YUT.getStepCount(), scanner);
+        // 걸(3) → 7
+        board.movePiece(p, YutResult.GEOL.getStepCount(), scanner);
+        // 걸(3) → 10
+        board.movePiece(p, YutResult.GEOL.getStepCount(), scanner);
+        // 걸(3) → 35
+        board.movePiece(p, YutResult.GEOL.getStepCount(), scanner);
+        assertEquals("35", p.position.name);
+        // 걸(3) → 0
+        board.movePiece(p, YutResult.GEOL.getStepCount(), scanner);
+        // 걸(3) → 완주
+        board.movePiece(p, YutResult.GEOL.getStepCount(), scanner);
+        assertTrue(p.finished);
+    }
+
+    /** f. 0(윷) -> 4(걸) -> 7(걸) -> 10(윷) -> 31 */
+    @Test
+    void testPentagonScenarioF() {
+        PentagonBoard board = new PentagonBoard();
+        Player player = new Player("P", 1, board);
+        Piece p = player.pieces.get(0);
+
+        board.movePiece(p, YutResult.YUT.getStepCount(), scanner);   // →4
+        board.movePiece(p, YutResult.GEOL.getStepCount(), scanner);  // →7
+        board.movePiece(p, YutResult.GEOL.getStepCount(), scanner);  // →10
+        board.movePiece(p, YutResult.YUT.getStepCount(), scanner);   // →31 (10번 숏컷 중앙 진입 후)
+        assertEquals("31", p.position.name);
+    }
+
+    /** g. 0(윷) -> 4(모) -> 9(모) -> 14(도) -> 15(윷) -> 31 */
+    @Test
+    void testPentagonScenarioG() {
+        PentagonBoard board = new PentagonBoard();
+        Player player = new Player("P", 1, board);
+        Piece p = player.pieces.get(0);
+
+        board.movePiece(p, YutResult.YUT.getStepCount(), scanner);   // 윷 →4
+        board.movePiece(p, YutResult.MO.getStepCount(), scanner);    // 모 →9
+        board.movePiece(p, YutResult.MO.getStepCount(), scanner);    // 모 →14
+        board.movePiece(p, YutResult.DO.getStepCount(), scanner);    // 도 →15
+        board.movePiece(p, YutResult.YUT.getStepCount(), scanner);   // 윷 →31
+        assertEquals("31", p.position.name);
+    }
+
+    /** h. 0(윷) -> 4(모) -> 9(모) -> 14(도) -> 15(걸) -> 35(개) -> 34 */
+    @Test
+    void testPentagonScenarioH() {
+        PentagonBoard board = new PentagonBoard();
+        Player player = new Player("P", 1, board);
+        Piece p = player.pieces.get(0);
+
+        board.movePiece(p, YutResult.YUT.getStepCount(), scanner);   // 윷 →4
+        board.movePiece(p, YutResult.MO.getStepCount(), scanner);    // 모 →9
+        board.movePiece(p, YutResult.MO.getStepCount(), scanner);    // 모 →14
+        board.movePiece(p, YutResult.DO.getStepCount(), scanner);    // 도 →15
+        board.movePiece(p, YutResult.GEOL.getStepCount(), scanner);  // 걸 → central to 35
+        board.movePiece(p, YutResult.GAE.getStepCount(), scanner);   // 개 → 34
+        assertEquals("34", p.position.name);
     }
 
 }

--- a/src/test/java/GameFlowTest.java
+++ b/src/test/java/GameFlowTest.java
@@ -8,259 +8,42 @@ import java.util.Scanner;
 시험 끝난 후.. 진행하겠습니다.
  */
 
-@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@DisplayName("윷놀이 게임 테스트") // 전체 흐름 통합 테스트로 사용할 예정
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)  // BeforeAll 사용할 때 static 선언을 회피하기 위해
+
 public class GameFlowTest {
+    YutnoriGame game;
 
-    private Scanner scanner;
+    @BeforeAll
+    void beforeAll() {
+        game = new YutnoriGame();
+    }
 
-    @BeforeEach
-    void setUp() {
-        // movePiece 메서드 파라미터용 Scanner
-        scanner = new Scanner(System.in);
+    @Test
+    public void test1() {
+    }
+
+    @Test
+    public void test2() {
+
+    }
+
+
+    @Test
+    public void test3() {
+
+
+    }
+
+    @AfterAll
+    public void afterAll() {
+
     }
 
     @AfterEach
-    void tearDown() {
-        scanner.close();
-    }
+    public void afterEach() {
 
-    // ────────────────────────────────────────────────────────────
-    // 사각형 판 시나리오
-    // ────────────────────────────────────────────────────────────
 
-    /** a. 0(윷)→4(개)→6(윷)→10(윷)→26(걸)→완주 */
-    @Test
-    void testSquareScenarioA() {
-        SquareBoard board = new SquareBoard();
-        Player player = new Player("P", 1, board);
-        Piece piece = player.pieces.get(0);
 
-        board.movePiece(piece, 4, scanner);  // 윷
-        board.movePiece(piece, 2, scanner);  // 개
-        board.movePiece(piece, 4, scanner);  // 윷
-        board.movePiece(piece, 4, scanner);  // 윷
-        board.movePiece(piece, 3, scanner);  // 걸
-
-        assertTrue(piece.finished, "말이 완주되어야 합니다.");
-    }
-
-    /** b. 0(윷)→4(윷)→8(개)→10(윷)→26 (미완주) */
-    @Test
-    void testSquareScenarioB() {
-        SquareBoard board = new SquareBoard();
-        Player player = new Player("P", 1, board);
-        Piece piece = player.pieces.get(0);
-
-        board.movePiece(piece, 4, scanner);  // 윷 → 4
-        board.movePiece(piece, 4, scanner);  // 윷 → 8
-        board.movePiece(piece, 2, scanner);  // 개 → 10
-        board.movePiece(piece, 4, scanner);  // 윷 → 26
-
-        assertFalse(piece.finished, "완주되지 않아야 합니다.");
-        assertEquals(26, piece.position.id, "최종 위치는 26이어야 합니다.");
-    }
-
-    /** c. 0(윷)→4(윷)→8(윷)→12(걸)→15(걸)→18 */
-    @Test
-    void testSquareScenarioC() {
-        SquareBoard board = new SquareBoard();
-        Player player = new Player("P", 1, board);
-        Piece piece = player.pieces.get(0);
-
-        board.movePiece(piece, 4, scanner);  // 윷 → 4
-        board.movePiece(piece, 4, scanner);  // 윷 → 8
-        board.movePiece(piece, 4, scanner);  // 윷 → 12
-        board.movePiece(piece, 3, scanner);  // 걸 → 15
-        board.movePiece(piece, 3, scanner);  // 걸 → 18
-
-        assertFalse(piece.finished, "이 시나리오에서는 완주되지 않아야 합니다.");
-        assertEquals(18, piece.position.id, "최종 위치는 18이어야 합니다.");
-    }
-
-    /** d. 0(모) -> 5(걸) -> 28(걸) -> 0(개) -> 완주 */
-    @Test
-    void testSquareScenarioD() {
-        SquareBoard board = new SquareBoard();
-        Player player = new Player("P", 1, board);
-        Piece p = player.pieces.get(0);
-
-        // 모(5)
-        board.movePiece(p, YutResult.MO.getStepCount(), scanner);
-        assertEquals("5", p.position.name);
-
-        // 걸(3) → 28
-        board.movePiece(p, YutResult.GEOL.getStepCount(), scanner);
-        assertEquals("28", p.position.name);
-
-        // 걸(3) → 0 (완주 직전)
-        board.movePiece(p, YutResult.GEOL.getStepCount(), scanner);
-        assertEquals("0", p.position.name);
-
-        // 개(2) → 완주
-        board.movePiece(p, YutResult.GAE.getStepCount(), scanner);
-        assertTrue(p.finished, "개를 던진 후 완주되어야 합니다.");
-    }
-
-    /** e. 0(모) -> 5(윷) -> 24(걸) -> 16 */
-    @Test
-    void testSquareScenarioE() {
-        SquareBoard board = new SquareBoard();
-        Player player = new Player("P", 1, board);
-        Piece p = player.pieces.get(0);
-
-        // 모(5) → 5
-        board.movePiece(p, YutResult.MO.getStepCount(), scanner);
-        assertEquals("5", p.position.name);
-
-        // 윷(4) → 24 (5번에서 숏컷)
-        board.movePiece(p, YutResult.YUT.getStepCount(), scanner);
-        assertEquals("24", p.position.name);
-
-        // 걸(3) → 16
-        board.movePiece(p, YutResult.GEOL.getStepCount(), scanner);
-        assertEquals("16", p.position.name);
-    }
-
-    // ────────────────────────────────────────────────────────────
-    // 오각형 판 시나리오
-    // ────────────────────────────────────────────────────────────
-
-    /** a. 0(모)→5(개)→26(걸)→32 */
-    @Test
-    void testPentagonScenarioA() {
-        PentagonBoard board = new PentagonBoard();
-        Player player = new Player("P", 1, board);
-        Piece piece = player.pieces.get(0);
-
-        board.movePiece(piece, 5, scanner);  // 모 → 5
-        board.movePiece(piece, 2, scanner);  // 개 → 26
-        board.movePiece(piece, 3, scanner);  // 걸 → 32
-
-        assertFalse(piece.finished, "이 시나리오에서는 완주되지 않아야 합니다.");
-        assertEquals(32, piece.position.id, "최종 위치는 32이어야 합니다.");
-    }
-
-    /** b. 0(모)→5(걸)→35(걸)→0 */
-    @Test
-    void testPentagonScenarioB() {
-        PentagonBoard board = new PentagonBoard();
-        Player player = new Player("P", 1, board);
-        Piece piece = player.pieces.get(0);
-
-        board.movePiece(piece, 5, scanner);  // 모 → 5
-        board.movePiece(piece, 3, scanner);  // 걸 → 35
-        board.movePiece(piece, 3, scanner);  // 걸 → 0
-
-        assertFalse(piece.finished, "완주 플래그는 지나치기 전까지는 켜지지 않습니다.");
-        assertEquals(board.getStart(), piece.position, "최종 위치는 출발점이어야 합니다.");
-    }
-
-    /** c. 0(모)→5(윷)→31(걸)→21 */
-    @Test
-    void testPentagonScenarioC() {
-        PentagonBoard board = new PentagonBoard();
-        Player player = new Player("P", 1, board);
-        Piece piece = player.pieces.get(0);
-
-        board.movePiece(piece, 5, scanner);  // 모 → 5
-        board.movePiece(piece, 4, scanner);  // 윷 → 31
-        board.movePiece(piece, 3, scanner);  // 걸 → 21
-
-        assertFalse(piece.finished, "이 시나리오에서는 완주되지 않아야 합니다.");
-        assertEquals(21, piece.position.id, "최종 위치는 21이어야 합니다.");
-    }
-
-    /** d. 0(윷) -> 4(걸) -> 7(걸) -> 10(개) -> 28(걸) -> 32 */
-    @Test
-    void testPentagonScenarioD() {
-        PentagonBoard board = new PentagonBoard();
-        Player player = new Player("P", 1, board);
-        Piece p = player.pieces.get(0);
-
-        // 윷(4) → 4
-        board.movePiece(p, YutResult.YUT.getStepCount(), scanner);
-        assertEquals("4", p.position.name);
-
-        // 걸(3) → 7
-        board.movePiece(p, YutResult.GEOL.getStepCount(), scanner);
-        assertEquals("7", p.position.name);
-
-        // 걸(3) → 10
-        board.movePiece(p, YutResult.GEOL.getStepCount(), scanner);
-        assertEquals("10", p.position.name);
-
-        // 개(2) → 28 (10번에서 숏컷으로 중앙 진입 → 28)
-        board.movePiece(p, YutResult.GAE.getStepCount(), scanner);
-        assertEquals("28", p.position.name);
-
-        // 걸(3) → 32
-        board.movePiece(p, YutResult.GEOL.getStepCount(), scanner);
-        assertEquals("32", p.position.name);
-    }
-
-    /** e. 0(윷) -> 4(걸) -> 7(걸) -> 10(걸) -> 35(걸) -> 0 */
-    @Test
-    void testPentagonScenarioE() {
-        PentagonBoard board = new PentagonBoard();
-        Player player = new Player("P", 1, board);
-        Piece p = player.pieces.get(0);
-
-        // 윷(4) → 4
-        board.movePiece(p, YutResult.YUT.getStepCount(), scanner);
-        // 걸(3) → 7
-        board.movePiece(p, YutResult.GEOL.getStepCount(), scanner);
-        // 걸(3) → 10
-        board.movePiece(p, YutResult.GEOL.getStepCount(), scanner);
-        // 걸(3) → 35
-        board.movePiece(p, YutResult.GEOL.getStepCount(), scanner);
-        assertEquals("35", p.position.name);
-        // 걸(3) → 0 (완주)
-        board.movePiece(p, YutResult.GEOL.getStepCount(), scanner);
-        assertTrue(p.finished);
-    }
-
-    /** f. 0(윷) -> 4(걸) -> 7(걸) -> 10(윷) -> 31 */
-    @Test
-    void testPentagonScenarioF() {
-        PentagonBoard board = new PentagonBoard();
-        Player player = new Player("P", 1, board);
-        Piece p = player.pieces.get(0);
-
-        board.movePiece(p, YutResult.YUT.getStepCount(), scanner);   // →4
-        board.movePiece(p, YutResult.GEOL.getStepCount(), scanner);  // →7
-        board.movePiece(p, YutResult.GEOL.getStepCount(), scanner);  // →10
-        board.movePiece(p, YutResult.YUT.getStepCount(), scanner);   // →31 (10번 숏컷 중앙 진입 후)
-        assertEquals("31", p.position.name);
-    }
-
-    /** g. 0(윷) -> 4(모) -> 9(모) -> 14(도) -> 15(윷) -> 31 */
-    @Test
-    void testPentagonScenarioG() {
-        PentagonBoard board = new PentagonBoard();
-        Player player = new Player("P", 1, board);
-        Piece p = player.pieces.get(0);
-
-        board.movePiece(p, YutResult.YUT.getStepCount(), scanner);   // 윷 →4
-        board.movePiece(p, YutResult.MO.getStepCount(), scanner);    // 모 →9
-        board.movePiece(p, YutResult.MO.getStepCount(), scanner);    // 모 →14
-        board.movePiece(p, YutResult.DO.getStepCount(), scanner);    // 도 →15
-        board.movePiece(p, YutResult.YUT.getStepCount(), scanner);   // 윷 →31
-        assertEquals("31", p.position.name);
-    }
-
-    /** h. 0(윷) -> 4(모) -> 9(모) -> 14(도) -> 15(걸) -> 35(개) -> 34 */
-    @Test
-    void testPentagonScenarioH() {
-        PentagonBoard board = new PentagonBoard();
-        Player player = new Player("P", 1, board);
-        Piece p = player.pieces.get(0);
-
-        board.movePiece(p, YutResult.YUT.getStepCount(), scanner);   // 윷 →4
-        board.movePiece(p, YutResult.MO.getStepCount(), scanner);    // 모 →9
-        board.movePiece(p, YutResult.MO.getStepCount(), scanner);    // 모 →14
-        board.movePiece(p, YutResult.DO.getStepCount(), scanner);    // 도 →15
-        board.movePiece(p, YutResult.GEOL.getStepCount(), scanner);  // 걸 → central to 35
-        board.movePiece(p, YutResult.GAE.getStepCount(), scanner);   // 개 → 34
-        assertEquals("34", p.position.name);
     }
 }


### PR DESCRIPTION
1. 디버그 보드 위치 수정 (빽도 시 미출력) - Board class
디버그 보드가 빽도 수행 시에는 미출력되어서 위치를 수정했습니다. 

2. 연속 빽도 시 오류 수정 - Board class
기존 빽도 로직에서 첫 빽도는 정상적으로 수행되나 연속으로 빽도가 나올 경우 2칸씩 후진하는 오류를 발견했습니다.
기존 로직은 pop 을 2번하며 빽도를 진행하는 것으로 확인되어 마지막 pop 을 peek 으로 변경 하고 StackEmptyException 이 발생하지 않도록 로직을 좀 수정했습니다.

3. 보드 판에 진입한 말이 start 지점에서 positive step 이 나올 경우 완주 처리 - Board class
보드 판에 진입한 말이 start 지점 (0) 에 도착한 후 positive step 이 나왔을 때 완주 처리가 되지 않고 한 바퀴를 더 도는 오류가 있었고 추가 예외 처리로 완주할 수 있도록 했습니다.

4. start 지점에서 빽도 수행시 한 칸 전진 - Board class & Piece class
start 지점에서 빽도 step 발생시 한 칸 전진할 수 있도록 했습니다. 이를 위해 Piece class 에 lastPosition 변수를 추가하여 직전 위치를 계속 기억할 수 있게 하여 한 칸 전진 할 수 있게 하였습니다. (기존 빽도 로직을 사용할 경우 StackEmptyException 이 발생하고, 처음에는 start 지점에서 빽도일 경우 도 step 으로 움직이도록 예외 처리 하였으나, 그렇게 되면 positive step 으로 인식하는 오류가 발생하여 이와 같은 로직을 적용했습니다.) 

> TestCase (TestStartPointBaekDo & TestStartPointBaekDo1) 추가했습니다. 위 수정 사항들 모두 확인 가능합니다.

+ 현재 완주된 말이 보드를 빠져나가는 것이 아닌 start 지점 (0) 에 위치하여 0에 도착하는 말들에게 잡히는 오류(추가 윷 던지기 기회 제공) 가 발생함을 확인했습니다.

+ 지금 Board class 의 movePiece 에 너무 많은 기능이 치중되어서 리팩토링이 불가피할 것 같습니다.

+ TestCase 들도 더 추가해야 할 것 같습니다~

